### PR TITLE
MBS-10668: Fix overflow bug in overview with more than 15 participants

### DIFF
--- a/scss/content.scss
+++ b/scss/content.scss
@@ -63,6 +63,10 @@
         width: 100%;
         height: 600px;
         justify-content: center;
+        // MBS-10668: Prevent overflow of long result list inside the container
+        &.mootimeter-height-auto {
+          height: auto;
+        }
       }
 
       @media screen and (max-width: 539px) {
@@ -174,6 +178,10 @@
         &.mootimeter-width-xl {
           height: 80vH;
           justify-content: center;
+          // MBS-10668: Prevent overflow of long result list inside the container
+          &.mootimeter-height-auto {
+            height: auto;
+          }
         }
 
       }

--- a/styles.css
+++ b/styles.css
@@ -67,18 +67,22 @@
 }
 
 @font-face {
-  font-display: swap;
-  font-family: "Atkinson Hyperlegible";
-  font-style: normal;
-  font-weight: 400;
-  src: url("/mod/mootimeter/fonts/atkinson-hyperlegible-v11-latin-regular.woff2") format("woff2"); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  .mootimetercontainer {
+    font-display: swap;
+    font-family: "Atkinson Hyperlegible";
+    font-style: normal;
+    font-weight: 400;
+    src: url("/mod/mootimeter/fonts/atkinson-hyperlegible-v11-latin-regular.woff2") format("woff2"); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  }
 }
 @font-face {
-  font-display: swap;
-  font-family: "Lexend";
-  font-style: normal;
-  font-weight: 400;
-  src: url("/mod/mootimeter/fonts/lexend-v18-latin-regular.woff2") format("woff2"); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  .mootimetercontainer {
+    font-display: swap;
+    font-family: "Lexend";
+    font-style: normal;
+    font-weight: 400;
+    src: url("/mod/mootimeter/fonts/lexend-v18-latin-regular.woff2") format("woff2"); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  }
 }
 .mootimetercontainer h1,
 .mootimetercontainer h2,
@@ -198,6 +202,7 @@
   justify-content: center;
   position: relative;
   min-width: 95px;
+  transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 }
 .mootimetercontainer .mootimetercolpages ul li:hover {
   border-color: #e99f80;
@@ -543,6 +548,9 @@
   height: 600px;
   justify-content: center;
 }
+.mootimetercontainer .mootimetercolcontent .mootimeter-colcontent-preview.mootimeter-width-xl.mootimeter-height-auto {
+  height: auto;
+}
 @media screen and (max-width: 539px) {
   .mootimetercontainer .mootimetercolcontent .mootimeter-colcontent-preview {
     padding: 1rem;
@@ -627,6 +635,9 @@
 .mootimetercontainer.fullscreen .mootimetercolcontent .mootimeter-colcontent-preview.mootimeter-width-xl {
   height: 80vH;
   justify-content: center;
+}
+.mootimetercontainer.fullscreen .mootimetercolcontent .mootimeter-colcontent-preview.mootimeter-width-xl.mootimeter-height-auto {
+  height: auto;
 }
 
 .mootimetercontainer .divider {

--- a/tools/quiz/templates/view_overview.mustache
+++ b/tools/quiz/templates/view_overview.mustache
@@ -1,4 +1,4 @@
-<div class="mootimeter-colcontent-preview mootimeter-width-xl">
+<div class="mootimeter-colcontent-preview mootimeter-width-xl mootimeter-height-auto">
     <table class="table" id="mtmt_quiz_overview_{{uniqid}}">
         <thead>
             <tr>


### PR DESCRIPTION
Closes #197

Fix result list overflow in answer overview: Added CSS modifier class `mootimeter-height-auto` to override the fixed height: 600px on .mootimeter-width-xl containers (also in fullscreen mode) in `view_overview.mustache`; 